### PR TITLE
New laurent api

### DIFF
--- a/examples/impossible_quadratization_for_given_input_variables_restrictions.py
+++ b/examples/impossible_quadratization_for_given_input_variables_restrictions.py
@@ -1,7 +1,6 @@
 import sympy as sp
 from qbee import *
 from functools import partial
-from time import time
 
 if __name__ == '__main__':
     c1, c2, c3, c4, T = functions("c1, c2, c3, c4, T")
@@ -17,6 +16,6 @@ if __name__ == '__main__':
     no_quad_pruning = partial(pruning_by_nodes_without_quadratization_found, nodes_processed=100)
     # {T: 1} means than T can have a derivative of order at most one => T'
     quadr_system = polynomialize_and_quadratize(system, input_der_orders={T: 1},
-                                                    pruning_functions=[no_quad_pruning] + default_pruning_rules)
+                                                pruning_functions=[no_quad_pruning] + default_pruning_rules)
     if quadr_system:
         print(quadr_system)

--- a/examples/solarwind_laurent.py
+++ b/examples/solarwind_laurent.py
@@ -15,6 +15,6 @@ if __name__ == '__main__':
         (v3, v3t)
     ]
 
-    quadr_system = polynomialize_and_quadratize(system, keep_laurent=True)
+    quadr_system = polynomialize_and_quadratize(system)
     if quadr_system:
         print(quadr_system)

--- a/qbee/__init__.py
+++ b/qbee/__init__.py
@@ -21,7 +21,7 @@ from .printer import print_qbee
 INDEPENDENT_VARIABLE = sp.Symbol("_t")
 
 
-def functions(names, **kwargs):
+def functions(names, *, laurent=True, **kwargs):
     """Dependent and input variables in differential equations. The syntax is identical to `sympy.symbols`_.
 
     Examples
@@ -30,14 +30,14 @@ def functions(names, **kwargs):
     .. _sympy.symbols: https://docs.sympy.org/latest/modules/core.html?highlight=symbols#sympy.core.symbol.symbols
     """
     t = INDEPENDENT_VARIABLE
-    funcs = sp.symbols(names, cls=sp.Function, **kwargs)
+    funcs = sp.symbols(names, cls=sp.Function, is_laurent=laurent, **kwargs)
     if isinstance(funcs, Iterable):
         return [f(t) for f in funcs]
     return funcs(t)
 
 
-def multivariable_functions(names, args, **kwargs):
-    funcs = sp.symbols(names, cls=sp.Function, **kwargs)
+def multivariable_functions(names, args, *, laurent=True, **kwargs):
+    funcs = sp.symbols(names, cls=sp.Function, is_laurent=laurent, **kwargs)
     if isinstance(funcs, Iterable):
         return [f(*args) for f in funcs]
     return funcs(*args)

--- a/qbee/polynomialization.py
+++ b/qbee/polynomialization.py
@@ -203,7 +203,7 @@ class EquationSystem:
         for var in expr.free_symbols.difference(self.variables.parameter).difference(self.variables.input):
             var_diff = self._equations[var]
             if isinstance(expr, sp.Pow) and isinstance(expr.exp, sp.Float):
-                result += sp.Mul(expr.exp * var_diff, expr, sp.Pow(var, -1), evaluate=False)
+                result += sp.Mul(var_diff, expr.diff(var) * expr.base, sp.Pow(expr.base, -1), evaluate=False)
             elif isinstance(expr, sp.Pow) and expr.exp == sp.Integer(-1):
                 result += sp.Mul(var_diff, expr.diff(var), evaluate=False)
             else:

--- a/qbee/polynomialization.py
+++ b/qbee/polynomialization.py
@@ -172,6 +172,7 @@ class EquationSystem:
             self._equations[x] = fx.expand()
 
     def is_polynomial(self) -> bool:
+        self._fill_poly_system()  # possible performance issue
         return all(self._poly_equations.values())
 
     def add_new_var(self, substitution: sp.Expr, new_var: sp.Symbol | None = None) -> None:

--- a/qbee/polynomialization.py
+++ b/qbee/polynomialization.py
@@ -262,9 +262,10 @@ class EquationSystem:
         return base ** exp
 
     def _replace_irrational_pow(self, base, exp):
-        new_var = key_from_value(self._substitution_equations, base ** exp)
-        if exp.is_Float and new_var:
-            return new_var
+        if exp.is_Float:
+            new_vars = [k for k, v in self._substitution_equations.items()
+                        if v.is_Pow and v.base == base and math.isclose(v.exp, exp)]
+            return new_vars[0] if len(new_vars) != 0 else base ** exp
         return base ** exp
 
     def _is_expr_polynomial(self, expr: sp.Expr):

--- a/qbee/polynomialization.py
+++ b/qbee/polynomialization.py
@@ -8,7 +8,7 @@ import sympy as sp
 from functools import cached_property
 from sympy.core.function import AppliedUndef
 from sympy.polys.rings import PolyRing
-from typing import Iterator
+from typing import Iterator, Collection
 from ordered_set import OrderedSet
 from .util import *
 from .printer import str_qbee
@@ -39,6 +39,7 @@ class VariablesHolder:
         self._generated_variables = list()
         self._base_name = new_var_base_name
         self._start_id = start_new_vars_with
+        self.laurent = list()
 
     @property
     def state(self):
@@ -100,9 +101,7 @@ class VariablesHolder:
 class EquationSystem:
     def __init__(self, equations: dict[sp.Symbol, sp.Expr],
                  parameter_variables: Iterable[sp.Symbol] = None,
-                 input_variables: Iterable[sp.Symbol] = None,
-                 keep_laurent=False):
-        self.keep_laurent = keep_laurent
+                 input_variables: Iterable[sp.Symbol] = None):
 
         self._equations = equations.copy()
         self._substitution_equations: dict[sp.Symbol, sp.Expr] = dict()
@@ -137,7 +136,6 @@ class EquationSystem:
         return [sp.Eq(make_derivative_symbol(x), f) for x, f in self._poly_equations.items()]
 
     def to_poly_equations(self, inputs_ord: dict):
-        """System should be already polynomial unless `keep_laurent` is True."""
         self._fill_poly_system()
         inputs_ord_sym = {sp.Symbol(str_qbee(k)): v for k, v in inputs_ord.items()}
         d_inputs = generate_derivatives(inputs_ord_sym)
@@ -146,11 +144,8 @@ class EquationSystem:
         # noinspection PyTypeChecker
         R, *_ = sp.ring(list(self.variables.state + sp.flatten(d_inputs)), coef_field)
 
-        if self.keep_laurent:
-            equations = make_laurent_poly([eq.rhs for eq in self.polynomial_equations],
-                                          self.variables.state, R)
-        else:
-            equations = [R(eq.rhs) for eq in self.polynomial_equations]
+        equations = make_laurent_poly([eq.rhs for eq in self.polynomial_equations],
+                                      self.variables.state, sp.flatten(d_inputs), R)
 
         for i, v in enumerate(inputs_ord_sym.keys()):
             for dv in [g for g in R.gens if str(v) + '\'' in str(g)]:
@@ -168,7 +163,8 @@ class EquationSystem:
         Therefore, this property is cached and could lead to incorrect results if you change
         `self._substitution_equations` or `self.variables`
         """
-        return {k: v for k, v in self._substitution_equations.items() if 1 / v in self.variables.state}
+        return {k: v for k, v in self._substitution_equations.items()
+                if 1 / v in self.variables.laurent}
 
     def expand(self):
         """Apply SymPy 'expand' function to each of equation."""
@@ -178,7 +174,7 @@ class EquationSystem:
     def is_polynomial(self) -> bool:
         return all(self._poly_equations.values())
 
-    def add_new_var(self, new_var: sp.Symbol, substitution: sp.Expr) -> None:
+    def add_new_var(self, substitution: sp.Expr, new_var: sp.Symbol | None = None) -> None:
         """
         Add a `new_var = substitution` to the system.
 
@@ -186,10 +182,15 @@ class EquationSystem:
         * can add more than one variable recursively
         * can change whether the system is polynomial or not
         """
-        if not self.keep_laurent and substitution.is_Pow \
-                and (substitution.exp < 0 and substitution.exp != -1) \
-                and (1 / substitution.base) not in self._substitution_equations.values():
-            self.add_new_var(new_var, 1 / substitution.base)
+        if substitution in self._substitution_equations.values():
+            return
+        if new_var is None:
+            new_var = self.variables.create()
+        if substitution.is_Pow \
+                and substitution.exp.is_Float \
+                and (1 / substitution.base) not in self._substitution_equations.values() \
+                and substitution.base not in self.variables.laurent:
+            self.add_new_var(1 / substitution.base, new_var)
             new_var = self.variables.create()
         self._substitution_equations[new_var] = substitution
         self._equations[new_var] = self._calculate_Lie_derivative(substitution)
@@ -267,10 +268,11 @@ class EquationSystem:
         return base ** exp
 
     def _is_expr_polynomial(self, expr: sp.Expr):
-        if self.keep_laurent:
-            found = find_nonpolynomial_terms(expr, set(self.variables.state) | self.variables.input, keep_laurent=True)
-            return len(found) == 0
-        return expr.is_polynomial(*self.variables.state, *self.variables.input)
+        if not self.variables.laurent:  # performance optimization
+            return expr.is_polynomial(*self.variables.state, *self.variables.input)
+
+        non_polynomials = find_nonpolynomial_terms(expr, set(self.variables.state) | self.variables.input)
+        return len(filter_laurent_monoms(self, non_polynomials)) == 0
 
     def print(self, str_func=str_qbee, use_poly_equations=True):
         """
@@ -316,14 +318,17 @@ def eq_list_to_eq_system(system: List[Tuple[sp.Symbol, sp.Expr]]) -> EquationSys
     funcs = set(reduce(lambda l, r: l | r, [eq.atoms(AppliedUndef) for eq in rhs]))
     lhs_args = set(sp.flatten([eq.args for eq in lhs if not isinstance(eq, sp.Derivative)]))
     inputs = set(filter(lambda f: (f not in lhs) and (f not in lhs_args), funcs))
-    spatial = funcs.difference(inputs)
+    spatial = set(reduce(lambda l, r: l | r, [eq.atoms(sp.Derivative) for eq in rhs]))
+    spatial = {f for f in spatial if set(lhs).intersection(set(list(zip(*f.variable_count))[0]))}
+    laurent = {f for f in funcs if f.is_laurent}
 
-    degrade_to_symbol = {s: sp.Symbol(str_qbee(s)) for s in funcs | inputs | params | set(lhs)}
+    degrade_to_symbol = {s: sp.Symbol(str_qbee(s)) for s in funcs | inputs | params | set(lhs) | spatial}
 
     params_sym = [p.subs(degrade_to_symbol) for p in params]
     funcs_sym = [f.subs(degrade_to_symbol) for f in funcs]
-    inputs_sym = [i.subs(degrade_to_symbol) for i in inputs]
-    spacial_sym = [s.subs(degrade_to_symbol) for s in spatial]
+    inputs_sym = {i.subs(degrade_to_symbol) for i in inputs}
+    spacial_sym = {s.subs(degrade_to_symbol) for s in spatial}
+    laurent_sym = [f.subs(degrade_to_symbol) for f in laurent]
 
     lhs_sym = [s.subs(degrade_to_symbol) for s in lhs]
     rhs_sym = [eq.subs(degrade_to_symbol) for eq in rhs]
@@ -331,12 +336,13 @@ def eq_list_to_eq_system(system: List[Tuple[sp.Symbol, sp.Expr]]) -> EquationSys
     der_inputs = set(reduce(lambda l, r: l | r, [eq.atoms(sp.Derivative) for eq in rhs]))
     degrade_to_symbol.update({i: sp.Symbol(str_qbee(i)) for i in der_inputs})
     rhs_sym = [eq.subs(degrade_to_symbol) for eq in rhs]
-    system = EquationSystem({dx: fx for dx, fx in zip(lhs_sym, rhs_sym)}, params_sym, inputs_sym)
-    system.variables._state_variables = list(OrderedSet(system.variables.state + spacial_sym))
+    system = EquationSystem({dx: fx for dx, fx in zip(lhs_sym, rhs_sym)},
+                            params_sym, inputs_sym | spacial_sym.difference(lhs_sym))
+    system.variables.laurent = laurent_sym
     return system
 
 
-def polynomialize(system: EquationSystem | list[(sp.Symbol, sp.Expr)], upper_bound=10, keep_laurent=True,
+def polynomialize(system: EquationSystem | list[(sp.Symbol, sp.Expr)], upper_bound=10,
                   new_var_name="w_", start_new_vars_with=0) -> EquationSystem:
     """
     Transforms the system into polynomial form using variable substitution techniques.
@@ -344,7 +350,6 @@ def polynomialize(system: EquationSystem | list[(sp.Symbol, sp.Expr)], upper_bou
     :param system: non-linear ODEs system
     :param upper_bound: a maximum number of new variables that algorithm can introduce.
      If infinite, the algorithm may never stop.
-    :param keep_laurent: if True do not introduce integer negative powers as new variables.
     :param new_var_name: base name for new variables. Example: new_var_name='w' => w0, w1, w2, ...
     :param start_new_vars_with: Initial index for new variables. Example: start_new_vars_with=3 => w3, w4, ...
 
@@ -354,18 +359,15 @@ def polynomialize(system: EquationSystem | list[(sp.Symbol, sp.Expr)], upper_bou
     system.variables.base_var_name = new_var_name
     system.variables.start_new_vars_with = start_new_vars_with
     nvars, opt_system, traversed = poly_algo_step(system, upper_bound, math.inf)
-    if keep_laurent:
-        return make_laurent(system, opt_system)
-    return opt_system
+    return make_laurent(system, opt_system)
 
 
 def make_laurent(orig_system: EquationSystem, poly_system: EquationSystem) -> EquationSystem:
     non_laurent_subs = set(poly_system._substitution_equations.values()) \
         .difference(set(poly_system.laurent_substitutions.values()))
     laurent_system = copy.copy(orig_system)
-    laurent_system.keep_laurent = True
     for subs in non_laurent_subs:
-        laurent_system.add_new_var(laurent_system.variables.create(), subs)
+        laurent_system.add_new_var(subs)
     return laurent_system
 
 
@@ -410,26 +412,41 @@ def next_gen(system: EquationSystem) -> Iterator[EquationSystem]:
 def apply_substitution(system: EquationSystem, subs: sp.Expr) -> EquationSystem:
     # new_system: EquationSystem = pickle.loads(pickle.dumps(system, -1))  # fast deepcopy
     new_system = copy.copy(system)
-    new_var = new_system.variables.create()
-    new_system.add_new_var(new_var, subs)
+    new_system.add_new_var(subs)
     return new_system
 
 
 def available_substitutions(system: EquationSystem) -> set[sp.Expr]:
     non_poly_equations = [eq for eq, peq in zip(system.equations, system.polynomial_equations) if not peq.rhs]
-    subs = [find_nonpolynomial_terms(eq.rhs, set(system.variables.state) | system.variables.input, keep_laurent=False)
+    subs = [find_nonpolynomial_terms(eq.rhs, set(system.variables.state) | system.variables.input)
             for eq in non_poly_equations]
     non_empty_subs = filter(lambda s: s, subs)
-    unused_subs = set(filter(lambda s: s not in system._substitution_equations.values(), sp.flatten(non_empty_subs)))
-    return unused_subs
+    system_subs_rhs = [eq.rhs for eq in system.substitution_equations]
+    unused_subs = {s for s in sp.flatten(non_empty_subs)
+                   if not (s in system_subs_rhs or (s.is_Pow and find_pow(system_subs_rhs, s) is not None))}
+    return filter_laurent_monoms(system, unused_subs)
 
 
-def find_nonpolynomial_terms(expr: sp.Expr, variables, keep_laurent=False) -> set:
-    found = expr.find(lambda subexpr: is_nonpolynomial_function(subexpr, variables))
-    if keep_laurent:
-        return set(filter(lambda e: not (e.is_Pow and e.exp.is_Integer and e.exp < 0
-                                         and isinstance(e.base, sp.Symbol)), found))
-    return found
+def find_pow(values: Collection[sp.Expr], pow: sp.Pow) -> sp.Pow | None:
+    all_matches = [v for v in values if v.is_Pow and v.base == pow.base and math.isclose(v.exp, pow.exp)]
+    if all_matches:
+        return all_matches[0]
+    return None
+
+
+def find_nonpolynomial_terms(expr: sp.Expr, variables) -> set:
+    return expr.find(lambda subexpr: is_nonpolynomial_function(subexpr, variables))
+
+
+def filter_laurent_monoms(system: EquationSystem, exprs: Collection[sp.Expr]) -> set[sp.Expr]:
+    return {e for e in exprs if not (is_pow_with_negative_integer_exp(e) and e.base in system.variables.laurent)}
+
+
+def is_pow_with_negative_integer_exp(expr):
+    return expr.is_Pow and \
+           expr.exp.is_Integer and \
+           expr.exp < 0 and \
+           isinstance(expr.base, sp.Symbol)
 
 
 def is_nonpolynomial_function(expr: sp.Expr, variables) -> bool:
@@ -437,18 +454,19 @@ def is_nonpolynomial_function(expr: sp.Expr, variables) -> bool:
     return not any(negative_cond)
 
 
-def make_laurent_poly(system: list, variables, R: PolyRing) -> list:
-    laurent_variables = {1 / var: sp.Symbol(f"__w{i}") for i, var in enumerate(variables)}
+def make_laurent_poly(system: list, state_vars, input_vars, R: PolyRing) -> list:
+    vars = OrderedSet(state_vars) | OrderedSet(input_vars)
+    laurent_variables = {1 / var: sp.Symbol(f"__w{i}") for i, var in enumerate(vars)}
 
     def replace_negative(base, exp):
-        if exp.is_Integer and exp < 0:
+        if exp.is_Integer and exp < 0 and 1 / base in laurent_variables:
             return laurent_variables[1 / base] ** (-exp)
         return base ** exp
 
     poly_system = [poly.replace(sp.Pow, replace_negative) for poly in system]
-    R2, *_ = sp.ring([*variables, *laurent_variables.values()], R.domain)
+    R2, *_ = sp.ring([*vars, *laurent_variables.values()], R.domain)
     poly_system = [R2(poly) for poly in poly_system]
-    for var, orig_var in zip(laurent_variables.values(), variables):
+    for var, orig_var in zip(laurent_variables.values(), vars):
         frm = R2(var).LM.index(1)
         to = R2(orig_var).LM.index(1)
         poly_system = [replace_poly_element(poly, frm, to, -1) for poly in poly_system]

--- a/qbee/quadratization.py
+++ b/qbee/quadratization.py
@@ -382,7 +382,7 @@ class QuadratizationResult:
     @property
     def new_vars_count(self):
         return self.quadratization.new_vars_count() +\
-               (self.polynomialization.variables.generated if self.polynomialization else 0)
+               (len(self.polynomialization.variables.generated) if self.polynomialization else 0)
 
     def __len__(self):
         return len(self.lhs)

--- a/qbee/quadratization.py
+++ b/qbee/quadratization.py
@@ -95,7 +95,7 @@ def quadratize(polynomials: List[PolyElement],
 
 def polynomialize_and_quadratize_ode(system: Union[EquationSystem, List[Tuple[sp.Symbol, sp.Expr]]],
                                      input_der_orders=None, conditions: Collection["SystemCondition"] = (),
-                                     polynomialization_upper_bound=10, keep_laurent=False, calc_upper_bound=True,
+                                     polynomialization_upper_bound=10, calc_upper_bound=True,
                                      generation_strategy=default_generation,
                                      scoring: Scoring = default_scoring,
                                      pruning_functions: Collection["Pruning"] | None = None,
@@ -106,7 +106,6 @@ def polynomialize_and_quadratize_ode(system: Union[EquationSystem, List[Tuple[sp
 
     :param system: system of equations in the form [(X, f(X)), ...] where the left-hand side is the derivatives.
     :param input_der_orders: mapping of input variables to maximum order of their derivatives. For example {T: 2} => T in C2
-    :param keep_laurent: if True do not introduce integer negative powers as new variables.
     :param new_vars_name: base name for new variables. Example: new_var_name='z' => z0, z1, z2, ...
     :param start_new_vars_with: initial index for new variables. Example: start_new_vars_with=3 => w3, w4, ...
     :return: quadratized system or None if there is none found
@@ -148,7 +147,7 @@ def polynomialize_and_quadratize_ode(system: Union[EquationSystem, List[Tuple[sp
     if pb_enable:
         # TODO: temporary solution, should incorporate printing variables with non-integer powers into subs. equations
         print("Variables introduced in polynomialization:")
-    poly_system = polynomialize(system, polynomialization_upper_bound, keep_laurent,
+    poly_system = polynomialize(system, polynomialization_upper_bound,
                                 new_var_name=new_vars_name, start_new_vars_with=start_new_vars_with)
     if pb_enable:
         poly_system.print_substitutions()
@@ -172,7 +171,7 @@ def polynomialize_and_quadratize_ode(system: Union[EquationSystem, List[Tuple[sp
 
 def polynomialize_and_quadratize(start_system: List[Tuple[sp.Symbol, sp.Expr]], input_der_orders: Optional[Dict] = None,
                                  conditions: Collection["SystemCondition"] = (), polynomialization_upper_bound=10,
-                                 keep_laurent=True, calc_quadr_upper_bound=True,
+                                calc_quadr_upper_bound=True,
                                  generation_strategy=default_generation,
                                  scoring: Scoring = default_scoring,
                                  pruning_functions: Collection["Pruning"] | None = None,
@@ -195,7 +194,7 @@ def polynomialize_and_quadratize(start_system: List[Tuple[sp.Symbol, sp.Expr]], 
             print()
 
         quad_res = polynomialize_and_quadratize_ode(system, input_orders_with_pde, conditions,
-                                                    polynomialization_upper_bound, keep_laurent=keep_laurent,
+                                                    polynomialization_upper_bound,
                                                     calc_upper_bound=calc_quadr_upper_bound,
                                                     generation_strategy=generation_strategy, scoring=scoring,
                                                     pruning_functions=pruning_functions, new_vars_name=new_vars_name,

--- a/qbee/selection.py
+++ b/qbee/selection.py
@@ -5,9 +5,11 @@ from .util import *
 
 Scoring = Callable[['PolynomialSystem'], int]
 
-# Function for proposing some new variables (to be used in both generators
 
-def raw_generation(system, excl_vars):
+def raw_generation(system, excl_vars=None):
+    """Function for proposing some new variables (to be used in both generators"""
+    if excl_vars is None:
+        excl_vars = list()
     excl_indices = [np.argmax(v) for v in excl_vars]
     all_decomp = get_decompositions(system.get_smallest_nonsquare())
     if len(excl_indices) == 0:
@@ -24,21 +26,22 @@ def raw_generation(system, excl_vars):
             result.append(d)
     return result
 
-# Standard generation strategy with different scoring functions
 
-def default_generation(system, excl_vars):
+def default_generation(system, excl_vars=None):
+    """Standard generation strategy with different scoring functions"""
+    if excl_vars is None:
+        excl_vars = list()
     if len(system.nonsquares) == 0:
         return list()
     return raw_generation(system, excl_vars)
 
-#####
 
-"""
-Given two mappings from the variables to indices and a list of numbers
-creates a new list in which the values at the indices corresponding to 
-variables in `v_to_ind_from` are placed at positions as prescribed by `v_to_ind_to`
-"""
 def _map_indices(v_to_ind_from, v_to_ind_to, arr, no_class):
+    """
+    Given two mappings from the variables to indices and a list of numbers
+    creates a new list in which the values at the indices corresponding to
+    variables in `v_to_ind_from` are placed at positions as prescribed by `v_to_ind_to`
+    """
     result = [arr[i] if i in no_class else 0 for i in range(len(arr))]
     v_to_val = {v: arr[ind] for v, ind in v_to_ind_from.items()}
     for v, ind in v_to_ind_to.items():
@@ -46,7 +49,9 @@ def _map_indices(v_to_ind_from, v_to_ind_to, arr, no_class):
     return result
 
 
-def generation_semidiscretized(system, excl_vars):
+def generation_semidiscretized(system, excl_vars=None):
+    if excl_vars is None:
+        excl_vars = list()
     # recognizing the semidiscretized structure if not cashed already
     if not hasattr(system, "equivalence_classes"):
         system.equivalence_classes = dict()
@@ -83,7 +88,7 @@ def generation_semidiscretized(system, excl_vars):
         print(system.ind_to_class)
         print(system.ind_to_var)
         print(system.graph)
-    
+
     # producing sets of new variables
     decomposition = raw_generation(system, excl_vars)
     result = set()
@@ -116,7 +121,7 @@ def generation_semidiscretized(system, excl_vars):
                 extended_vars = set()
                 break
         if len(extended_vars) > 0:
-             result.add(tuple(sorted(list(extended_vars))))
+            result.add(tuple(sorted(list(extended_vars))))
     return result
 
 
@@ -124,6 +129,7 @@ def generation_semidiscretized(system, excl_vars):
 
 def empty_score(system) -> int:
     return 1
+
 
 def default_scoring(system) -> int:
     total_nonsquare = sum([sum(map(abs, m)) for m in system.nonsquares])
@@ -141,11 +147,11 @@ def smd_scoring(system) -> int:
     return sum(map(lambda s: _compute_smd(s, mlist), mlist))
 
 
-def _compute_scoring(sub: Tuple[int], eq_degs):
+def _compute_aeqd(sub: Tuple[int], eq_degs):
     mon_degs = map(lambda deg: deg + monomial_deg(sub) - 1, eq_degs)
     quad_discrepancies = filter(lambda x: x > 0, map(lambda d: d - 2, mon_degs))
     return sum(quad_discrepancies)
 
 
-def _compute_scoring(sub, mlist: list):
+def _compute_smd(sub, mlist: list):
     return (monomial_deg(sub) - 1) * len(list(filter(lambda m: monomial_divides(sub, m), mlist)))

--- a/tests/test_API.py
+++ b/tests/test_API.py
@@ -63,7 +63,7 @@ def test_already_quadratized_system():
         (x, y ** 2),
         (y, x ** 2)
     ])
-    assert len(res.quadratization.introduced_vars) == 0
+    assert res.new_vars_count == 0
 
 
 def test_scalar_pde():

--- a/tests/test_circular.py
+++ b/tests/test_circular.py
@@ -3,7 +3,7 @@ from qbee import *
 from examples import generate_circular
 
 
-strategies = [default_strategy, aeqd_strategy, smd_strategy]
+strategies = [default_scoring, aeqd_scoring, smd_scoring]
 pruning_funcs = [
     [pruning_by_quadratic_upper_bound],
     [pruning_by_squarefree_graphs],

--- a/tests/test_hard.py
+++ b/tests/test_hard.py
@@ -3,7 +3,7 @@ from qbee import *
 from examples import generate_hard
 
 
-strategies = [default_strategy, aeqd_strategy, smd_strategy]
+strategies = [default_scoring, aeqd_scoring, smd_scoring]
 pruning_funcs = [
     [pruning_by_quadratic_upper_bound],
     [pruning_by_squarefree_graphs],

--- a/tests/test_hill.py
+++ b/tests/test_hill.py
@@ -3,7 +3,7 @@ from qbee import *
 from examples import generate_hill
 
 
-strategies = [default_strategy, aeqd_strategy, smd_strategy]
+strategies = [default_scoring, aeqd_scoring, smd_scoring]
 pruning_funcs = [
     [pruning_by_quadratic_upper_bound],
     [pruning_by_squarefree_graphs],

--- a/tests/test_laurent.py
+++ b/tests/test_laurent.py
@@ -9,7 +9,7 @@ def test_sigmoid_inv_arg():
         (x, 1 / (1 + sp.exp(1 / x)))
     ]
 
-    res = polynomialize_and_quadratize(system, keep_laurent=True)
+    res = polynomialize_and_quadratize(system)
     assert res.new_vars_count == 5
 
 
@@ -41,7 +41,7 @@ def test_solarwind():
         (v3, v3t)
     ]
 
-    quadr_system = polynomialize_and_quadratize(system, keep_laurent=True)
+    quadr_system = polynomialize_and_quadratize(system)
     if quadr_system:
         print(quadr_system)
     assert quadr_system.new_vars_count == 11

--- a/tests/test_lifeware_conjecture.py
+++ b/tests/test_lifeware_conjecture.py
@@ -3,7 +3,7 @@ from qbee import *
 from examples import generate_lifeware_conjecture
 
 
-strategies = [default_strategy, aeqd_strategy, smd_strategy]
+strategies = [default_scoring, aeqd_scoring, smd_scoring]
 pruning_funcs = [
     [pruning_by_quadratic_upper_bound],
     [pruning_by_squarefree_graphs],

--- a/tests/test_polynomialization.py
+++ b/tests/test_polynomialization.py
@@ -1,18 +1,7 @@
 import pytest
 import sympy as sp
-
 from qbee import *
 from qbee.polynomialization import eq_list_to_eq_system
-
-
-def assert_check_poly(expected_system: EquationSystem, actual_system: EquationSystem):
-    try:
-        assert actual_system.equations == expected_system.equations
-    except AssertionError as e:
-        if actual_system.is_polynomial():
-            raise AssertionError("Systems are not equal but actual system is polynomial.")
-        else:
-            raise e
 
 
 def test_already_polynomial():
@@ -34,44 +23,44 @@ def test_sigmoid():
         (x, 1 / (1 + sp.exp(x)))
     ])
 
-    res = polynomialize(system, keep_laurent=False)
+    res = polynomialize(system)
     assert len(res) == 3
 
 
 def test_sigmoid_inv_arg():
-    x = functions("x")
+    x = functions("x", laurent=False)
     system = [
         (x, 1 / (1 + sp.exp(1 / x)))
     ]
 
-    res = polynomialize(system, keep_laurent=False)
+    res = polynomialize(system)
     assert len(res) == 4
 
 
 def test_nested_functions():
-    x = functions("x")
+    x = functions("x", laurent=False)
     system = eq_list_to_eq_system([
         (x, sp.sin(sp.exp(x)))
     ])
 
-    res = polynomialize(system, keep_laurent=False)
+    res = polynomialize(system)
     assert len(res) == 4
 
 
 def test_parameter():
-    x, y = functions("x, y")
+    x, y = functions("x, y", laurent=False)
     p = parameters("p")
     system = [
         (x, sp.exp(p * y)),
         (y, sp.exp(p * x))
     ]
-    res = polynomialize(system, upper_bound=4, keep_laurent=False)
+    res = polynomialize(system, upper_bound=4)
     assert all([eq.rhs.is_Mul and sp.Symbol("p") in eq.rhs.args
                 for eq in res.polynomial_equations[2:]])
 
 
 def test_combustion():
-    c1, c2, c3, c4, T = functions("c1, c2, c3, c4, T")
+    c1, c2, c3, c4, T = functions("c1, c2, c3, c4, T", laurent=False)
     A, Ea, Ru = parameters("A, Ea, Ru")
     eq1 = -A * sp.exp(-Ea / (Ru * T)) * c1 ** 0.2 * c2 ** 1.3
     system = [
@@ -81,5 +70,5 @@ def test_combustion():
         (c4, -2 * eq1)
     ]
 
-    res = polynomialize(system, upper_bound=8, keep_laurent=False)
+    res = polynomialize(system, upper_bound=8)
     assert len(res) == 10

--- a/tests/test_x_plus_1.py
+++ b/tests/test_x_plus_1.py
@@ -3,7 +3,7 @@ from qbee import *
 from examples import generate_x_plus_1
 
 
-strategies = [default_strategy, aeqd_strategy, smd_strategy]
+strategies = [default_scoring, aeqd_scoring, smd_scoring]
 pruning_funcs = [
     [pruning_by_quadratic_upper_bound],
     [pruning_by_squarefree_graphs],


### PR DESCRIPTION
Move management of Laurent polynomial both from parameters of `polynomialize` and `polynomialize_and_quadratized` functions and from EquationSystem to `functions(..., laurent: bool = True)`

Examples:
```python
x = functions("x", laurent=True)
system = [(x, 1/x)]
polynomialize(system)  # Will not introduce new variables

y = functions("y", laurent=False)
system2 = [(y, 1/y)]
polynomialize(system2)  # Will introduce a new variable w_0 = 1/y

system3 = [
    (x, 1/x),
    (y, 1/y)
]
polynomialize(system3)  # Will introduce w_0 = 1/y, but will not introduce w_1 = 1/x
```

There are also some bug fixes needed for both `dev' and this branch.